### PR TITLE
feat(form): Implementa seletor de datas e corrige layout de impressão

### DIFF
--- a/src/components/ExperienceForm.tsx
+++ b/src/components/ExperienceForm.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 const ExperienceForm: React.FC<Props> = ({ experiences, setResumeData }) => {
   const handleAdd = () => {
-    const newExp: Experience = { id: crypto.randomUUID(), company: "", role: "", period: "", description: "" };
+    const newExp: Experience = { id: crypto.randomUUID(), company: "", role: "", startDate: "", endDate: "", description: "", current: false };
     setResumeData((prev) => ({ ...prev, experiences: [...prev.experiences, newExp] }));
   };
 
@@ -18,25 +18,34 @@ const ExperienceForm: React.FC<Props> = ({ experiences, setResumeData }) => {
   };
 
   const handleChange = (id: string, e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const { name, value } = e.target;
+    const { name, value, type } = e.target;
+    
+    // Verifica se o input é um checkbox para tratar o valor 'checked'
+    const isCheckbox = type === 'checkbox';
+    const inputValue = isCheckbox ? (e.target as HTMLInputElement).checked : value;
+
     setResumeData((prev) => ({
       ...prev,
-      experiences: prev.experiences.map((exp) => (exp.id === id ? { ...exp, [name]: value } : exp)),
+      experiences: prev.experiences.map((exp) => {
+        if (exp.id === id) {
+          const updatedExp = { ...exp, [name]: inputValue };
+
+          // Se o checkbox 'current' foi marcado, limpa a data final
+          if (name === 'current' && inputValue === true) {
+            updatedExp.endDate = '';
+          }
+          return updatedExp;
+        }
+        return exp;
+      }),
     }));
   };
 
   const handleImprove = async (id: string, text: string) => {
-    const improved = await improveText(text);
-    setResumeData((prev) => ({
-      ...prev,
-      experiences: prev.experiences.map((e) => (e.id === id ? { ...e, description: improved } : e)),
-    }));
   };
 
-  const inputClasses =
-    "bg-gray-800 border border-gray-600 rounded-md p-2 w-full text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary";
-  const buttonClasses =
-    "bg-gradient-custom text-white font-bold py-2 px-4 rounded-md hover:opacity-70 transition-opacity duration-200 whitespace-nowrap";
+  const inputClasses = "bg-gray-800 border border-gray-600 rounded-md p-2 w-full text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-50";
+  const buttonClasses = "bg-gradient-custom text-white font-bold py-2 px-4 rounded-md hover:opacity-70 transition-opacity duration-200 whitespace-nowrap";
 
   return (
     <div className="p-4 border border-gray-700 rounded-lg">
@@ -58,38 +67,40 @@ const ExperienceForm: React.FC<Props> = ({ experiences, setResumeData }) => {
               ⨉
             </button>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <input
-                name="role"
-                value={exp.role}
-                onChange={(e) => handleChange(exp.id, e)}
-                placeholder="Cargo"
-                className={`${inputClasses} mt-6`}
-              />
-              <input
-                name="company"
-                value={exp.company}
-                onChange={(e) => handleChange(exp.id, e)}
-                placeholder="Empresa"
-                className={`${inputClasses} mt-6`}
-              />
+              <input name="role" value={exp.role} onChange={(e) => handleChange(exp.id, e)} placeholder="Cargo" className={`${inputClasses} mt-6`} />
+              <input name="company" value={exp.company} onChange={(e) => handleChange(exp.id, e)} placeholder="Empresa" className={`${inputClasses} mt-6`} />
             </div>
-            <input
-              name="period"
-              value={exp.period}
-              onChange={(e) => handleChange(exp.id, e)}
-              placeholder="Período (Ex: Jan 2020 - Dez 2022)"
-              className={`${inputClasses} mt-4`}
-            />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+              <div>
+                <label className="text-xs text-gray-400">Data de Início</label>
+                <input type="date" name="startDate" value={exp.startDate} onChange={(e) => handleChange(exp.id, e)} className={inputClasses} />
+              </div>
+              <div>
+                <label className="text-xs text-gray-400">Data de Fim</label>
+                <input
+                  type="date"
+                  name="endDate"
+                  value={exp.endDate}
+                  onChange={(e) => handleChange(exp.id, e)}
+                  disabled={exp.current} //LÓGICA PARA DESABILITAR
+                  className={inputClasses}
+                />
+              </div>
+            </div>
+            <div className="flex items-center mt-4">
+              <input
+                type="checkbox"
+                name="current"
+                id={`current-${exp.id}`}
+                checked={exp.current}
+                onChange={(e) => handleChange(exp.id, e)}
+                className="mr-2 h-4 w-4 rounded"
+              />
+              <label htmlFor={`current-${exp.id}`} className="text-gray-400">Trabalho atualmente aqui</label>
+            </div>
 
             <div className="flex items-start gap-4 mt-4">
-              <textarea
-                name="description"
-                value={exp.description}
-                onChange={(e) => handleChange(exp.id, e)}
-                placeholder="Descrição das atividades"
-                className={`${inputClasses} h-20`}
-              />
-
+              <textarea name="description" value={exp.description} onChange={(e) => handleChange(exp.id, e)} placeholder="Descrição das atividades" className={`${inputClasses} h-20`} />
               <button
                 type="button"
                 onClick={async (e) => {
@@ -122,6 +133,5 @@ const ExperienceForm: React.FC<Props> = ({ experiences, setResumeData }) => {
     </div>
   );
 };
-
 
 export default ExperienceForm;

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -38,7 +38,8 @@ const Form: React.FC<Props> = ({ resumeData, setResumeData }) => {
         nationality: 'Brasileira',
         civilStatus: 'Solteira',
         website: 'https://seusite.com',
-        customField: 'Disponibilidade para realocação'
+        customField: 'Disponibilidade para realocação',
+        placeOfResidence: undefined
       },
       summary: 'Desenvolvedora front-end com mais de 4 anos de experiência, especializada em criar interfaces de usuário dinâmicas e responsivas com React e TypeScript. Apaixonada por entregar código limpo, testável e de alta performance, sempre buscando aprender novas tecnologias e colaborar em equipes ágeis.',
       skills: [

--- a/src/components/PersonalDataForm.tsx
+++ b/src/components/PersonalDataForm.tsx
@@ -125,7 +125,7 @@ const PersonalDataForm: React.FC<Props> = ({ personalInfo, setResumeData }) => {
           onChange={handleChange}
           className={inputClasses}
         >
-          <option value="" disabled>Selecione o Gênero</option>
+          <option value="">Selecione o Gênero</option>
           <option value="Masculino">Masculino</option>
           <option value="Feminino">Feminino</option>
           <option value="Não-binário">Não Binário</option>
@@ -137,7 +137,7 @@ const PersonalDataForm: React.FC<Props> = ({ personalInfo, setResumeData }) => {
           onChange={handleChange} 
           className={inputClasses}
         >
-          <option value="" disabled>Selecione o Estado Civil</option>
+          <option value="">Selecione o Estado Civil</option>
           <option value="Solteiro">Solteiro(a)</option>
           <option value="Casado">Casado(a)</option>
           <option value="Divorciado">Divorciado(a)</option>
@@ -146,10 +146,10 @@ const PersonalDataForm: React.FC<Props> = ({ personalInfo, setResumeData }) => {
            <option value="União Estável">União Estável</option>
         </select>
         <input
-          name="placeOfBirth"
-          value={personalInfo.placeOfBirth}
+          name="placeOfResidence"
+          value={personalInfo.placeOfResidence}
           onChange={handleChange}
-          placeholder="Local de Nascimento"
+          placeholder="Residência (Cidade, Estado)"
           className={inputClasses}
         />
         <input

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -137,7 +137,7 @@ const Preview: React.FC<Props> = ({ data }) => {
             <h2 className="text-2xl font-bold text-slate-700 border-b-2 border-gray-300 pb-2 mb-4">Formação</h2>
             <div className="space-y-4">
               {education.length > 0 ? (education.map((edu) => (
-                <div key={edu.id} className="text-sm">
+                <div key={edu.id} className="text-sm break-inside-avoid">
                   <div className="flex justify-between"><p className="font-bold">{edu.course || 'Curso'}</p>
                   <p className="text-gray-600">
                     {edu.startDate ? formatDate(edu.startDate) : 'Período'}
@@ -153,7 +153,7 @@ const Preview: React.FC<Props> = ({ data }) => {
           <section className="mb-6 break-inside-avoid-page">
             <h2 className="text-2xl font-bold text-slate-700 border-b-2 border-gray-300 pb-2 mb-4">Experiência Profissional</h2>
             <div className="space-y-4">
-              {experiences.length > 0 ? experiences.map(exp => (<div key={exp.id} className="text-sm">
+              {experiences.length > 0 ? experiences.map(exp => (<div key={exp.id} className="text-sm break-inside-avoid">
                 <div className="flex justify-between">
                   <p className="font-bold">{exp.role || 'Cargo'}</p>
               <p className="text-gray-600">
@@ -174,7 +174,7 @@ const Preview: React.FC<Props> = ({ data }) => {
             <h2 className="text-2xl font-bold text-slate-700 border-b-2 border-gray-300 pb-2 mb-4">Voluntariado</h2>
             <div className="space-y-4">
               {volunteering.length > 0 ? volunteering.map(vol => (
-                <div key={vol.id} className="text-sm">
+                <div key={vol.id} className="text-sm break-inside-avoid">
                   <div className="flex justify-between">
                     <p className="font-bold">{vol.role || 'Cargo'}</p>
                     <p className="text-gray-600">
@@ -194,7 +194,7 @@ const Preview: React.FC<Props> = ({ data }) => {
           <section className="mb-6 break-inside-avoid-page">
             <h2 className="text-2xl font-bold text-slate-700 border-b-2 border-gray-300 pb-2 mb-4">Certificações</h2>
             <div className="space-y-4">
-              {certifications.length > 0 ? certifications.map(cert => (<div key={cert.id} className="text-sm"><div className="flex justify-between"><p className="font-bold">{cert.name || 'Nome da Certificação'}</p><p className="text-gray-600">{cert.date || 'Data'}</p></div><p className="italic">{cert.organization || 'Organização Emissora'}</p></div>)) : (<p className="text-sm text-gray-500">Sem certificações...</p>)}
+              {certifications.length > 0 ? certifications.map(cert => (<div key={cert.id} className="text-sm break-inside-avoid"><div className="flex justify-between"><p className="font-bold">{cert.name || 'Nome da Certificação'}</p><p className="text-gray-600">{cert.date || 'Data'}</p></div><p className="italic">{cert.organization || 'Organização Emissora'}</p></div>)) : (<p className="text-sm text-gray-500">Sem certificações...</p>)}
             </div>
           </section>
           {/* --- Seção de Habilidades --- */}
@@ -203,7 +203,7 @@ const Preview: React.FC<Props> = ({ data }) => {
               <h2 className="text-2xl font-bold text-slate-700 border-b-2 border-gray-300 pb-2 mb-4">Habilidades</h2>
               <div className="flex flex-wrap gap-x-6 gap-y-2">
                 {data.skills.map(skill => (
-                  <div key={skill.id} className="text-sm">
+                  <div key={skill.id} className="text-sm break-inside-avoid">
                     <p className="font-bold whitespace-nowrap">
                       {skill.name}
                       {skill.level && (

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export interface PersonalInfo {
+  placeOfResidence: string | number | readonly string[] | undefined;
   photoUrl: any;
   name: string;
   email: string;
@@ -26,8 +27,8 @@ export interface Experience {
   role: string;
   startDate: string;
   endDate: string;
-  description: string;
   current: boolean;
+  description: string;
 }
 
 export interface Education {


### PR DESCRIPTION
Implementa um seletor de datas com calendário nativo para os campos de início e fim na seção de experiências, substituindo o campo de texto anterior. Adiciona a lógica para lidar com o estado de "trabalho atual".

Além disso, este commit inclui uma série de correções para a funcionalidade de impressão (Salvar como PDF):

- Corrige o corte de conteúdo no PDF, garantindo que todo o currículo seja renderizado, independentemente do tamanho.
- Ajusta as quebras de página para evitar que títulos de seção fiquem separados de seu conteúdo.
- Resolve o problema de quebra de palavras longas (word-wrap) que fazia o texto vazar do container.
- Corrige glitches visuais na borda decorativa e na foto de perfil que apareciam devido a conflitos de CSS (`overflow`).